### PR TITLE
issue09a: UX polish — description fade, scroll fix, dark theme, search button alignment

### DIFF
--- a/src/common/i18next/langs/en.ts
+++ b/src/common/i18next/langs/en.ts
@@ -35,8 +35,7 @@ export const en = {
         typeDog: 'Type requested breed...',
     },
     errors: {
-        noBreed1: 'Oh no! This race is not ',
-        noBreed2: 'available yet. Keep looking!',
+        noBreed: 'Oh no! This breed is not available yet. Keep looking!',
     },
     readme: {
         about: `Modern React web application for exploring dog breeds with advanced search, image galleries, theme switching, and multi-language support.`,

--- a/src/common/i18next/langs/pl.ts
+++ b/src/common/i18next/langs/pl.ts
@@ -35,8 +35,7 @@ export const pl = {
         typeDog: 'Wpisz rasę, której szukasz...',
     },
     errors: {
-        noBreed1: 'Ajajaj! Tej rasy nie ma jeszcze',
-        noBreed2: ' w naszej bazie. Poszukaj innej.',
+        noBreed: 'Ajajaj! Tej rasy nie ma w naszej bazie. Poszukaj innej.',
     },
     readme: {
         about: `Nowoczesna aplikacja React do eksploracji ras psów z zaawansowanym wyszukiwaniem, galeriami zdjęć, przełączaniem motywów i obsługą wielu języków.`,

--- a/src/modules/DogDetails/DogGallery.tsx
+++ b/src/modules/DogDetails/DogGallery.tsx
@@ -70,7 +70,7 @@ export const DogGallery: FC<DogGalleryProps> = ({ imageList, mode }) => {
                 {t('headers.imageList')} - {capitalizeFirstLetter(breedName)}
                 {variant && ` ${capitalizeFirstLetter(variant)}`}
             </h2>
-            <p className="text-center mb-5 -large typography-secondary">
+            <p className="text-center mb-5 -large text-[color:var(--typography-primary)]">
                 {t('content.imageCount', { count: imageList.length })}
             </p>
             <>

--- a/src/modules/DogDetails/DogMain.tsx
+++ b/src/modules/DogDetails/DogMain.tsx
@@ -134,9 +134,13 @@ const DogMain: FC = () => {
                             :
                         </h1>
                         {isDescriptionLoading ? (
-                            <p className="animate-pulse">
-                                {t('content.loading')}
-                            </p>
+                            <div className="space-y-2 mt-1" aria-hidden="true">
+                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-full" />
+                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[92%]" />
+                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[96%]" />
+                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[85%]" />
+                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[90%]" />
+                            </div>
                         ) : description ? (
                             <p>{description}</p>
                         ) : (

--- a/src/modules/DogDetails/DogMain.tsx
+++ b/src/modules/DogDetails/DogMain.tsx
@@ -120,7 +120,7 @@ const DogMain: FC = () => {
     }
 
     return (
-        <div className="flex flex-col min-h-fit gap-2.5 max-w-[1200px] mx-auto px-5 pb-[100px]">
+        <div className="flex flex-col min-h-fit gap-2.5 max-w-[1200px] mx-auto px-5">
             <ModeNavigation />
             {renderContent()}
             {mode === ModeType.DETAILS && (

--- a/src/modules/DogDetails/DogMain.tsx
+++ b/src/modules/DogDetails/DogMain.tsx
@@ -133,22 +133,16 @@ const DogMain: FC = () => {
                                 : ''}
                             :
                         </h1>
-                        {isDescriptionLoading ? (
-                            <div className="space-y-2 mt-1" aria-hidden="true">
-                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-full" />
-                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[92%]" />
-                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[96%]" />
-                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[85%]" />
-                                <div className="h-4 bg-[color:var(--secondary)] opacity-40 rounded animate-pulse w-[90%]" />
-                            </div>
-                        ) : description ? (
-                            <p>{description}</p>
-                        ) : (
-                            <>
-                                <p>{t('content.dogDescription1')}</p>
-                                <p>{t('content.dogDescription2')}</p>
-                            </>
-                        )}
+                        <div className={`transition-opacity duration-300 ${isDescriptionLoading ? 'opacity-0' : 'opacity-100'}`}>
+                            {description ? (
+                                <p>{description}</p>
+                            ) : (
+                                <>
+                                    <p>{t('content.dogDescription1')}</p>
+                                    <p>{t('content.dogDescription2')}</p>
+                                </>
+                            )}
+                        </div>
                     </div>
 
                     {dogVariants.length > 0 && (

--- a/src/modules/DogSearch/Searchbar.tsx
+++ b/src/modules/DogSearch/Searchbar.tsx
@@ -101,7 +101,7 @@ export const Searchbar: FC = () => {
             </div>
             <button
                 type="button"
-                className="primary typography-secondary"
+                className="primary typography-secondary self-end"
                 onClick={() => onSearch(searchQuery as DogBreed)}
             >
                 {t('buttons.search')}

--- a/src/modules/DogSearch/Searchbar.tsx
+++ b/src/modules/DogSearch/Searchbar.tsx
@@ -101,7 +101,7 @@ export const Searchbar: FC = () => {
             </div>
             <button
                 type="button"
-                className="primary typography-secondary self-end"
+                className="primary typography-secondary mt-2"
                 onClick={() => onSearch(searchQuery as DogBreed)}
             >
                 {t('buttons.search')}

--- a/src/modules/DogSearch/Searchbar.tsx
+++ b/src/modules/DogSearch/Searchbar.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useRef, useState } from 'react'
+import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Autocomplete } from '../../components/Autocomplete'
@@ -23,12 +23,22 @@ export const Searchbar: FC = () => {
     const listboxId = 'dog-autocomplete-listbox'
     const activeOptionId = activeIndex >= 0 ? `dog-option-${activeIndex}` : undefined
 
+    const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const showError = () => {
+        setInputError(true)
+        if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+        errorTimerRef.current = setTimeout(() => setInputError(false), 3000)
+    }
+
+    useEffect(() => () => { if (errorTimerRef.current) clearTimeout(errorTimerRef.current) }, [])
+
     const onSearch = (breed: DogBreed) => {
         const normalized = breed.toLocaleLowerCase().trim()
         if (normalized) {
             const known = dogEntries.some(([name]) => name.toLowerCase() === normalized)
             if (!known) {
-                setInputError(true)
+                showError()
                 return
             }
             setInputError(false)
@@ -78,9 +88,10 @@ export const Searchbar: FC = () => {
                     value={searchQuery}
                 />
                 {inputError && (
-                    <p className="absolute text-red-500 text-[10px] mt-0.5 left-0 whitespace-nowrap">
-                        {t('errors.noBreed1')}{t('errors.noBreed2')}
-                    </p>
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-30 bg-red-600 text-white text-xs rounded px-2 py-1 whitespace-nowrap shadow-md">
+                        {t('errors.noBreed')}
+                        <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-red-600" />
+                    </div>
                 )}
                 {isFocused ? (
                     <Autocomplete dogList={dogEntries} onSearch={onSearch} onKeyboardRef={onKeyboardRef} listboxId={listboxId} onActiveIndexChange={setActiveIndex} />


### PR DESCRIPTION
## Summary
- Fade in breed description instead of skeleton to prevent layout shift
- Remove redundant bottom padding causing unnecessary scroll on details page
- Fix image count text invisible on dark theme
- Show invalid breed error as auto-dismissing tooltip with clean i18n string
- Align search button vertically with input

## Test plan
- [ ] Navigate to breed detail — description fades in, no layout jump
- [ ] Details page does not scroll when content fits viewport
- [ ] Gallery page — image count visible on dark theme
- [ ] Type invalid breed, submit — tooltip appears above input, auto-dismisses after 3s
- [ ] Search button vertically centered with input on all screen sizes